### PR TITLE
fix: simplify GitHub release tag checkout in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,19 +64,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: 🏷️ Fetch latest tag
-        run: |
-          # Fetch all tags from remote
-          git fetch --tags
-          
-          # Checkout the specific tag created by the release job
-          if [ -n "${{ needs.release.outputs.tag }}" ]; then
-            echo "Checking out tag: ${{ needs.release.outputs.tag }}"
-            git checkout ${{ needs.release.outputs.tag }}
-          else
-            echo "No tag output from release job, using current commit"
-          fi
+          ref: ${{ needs.release.outputs.tag || github.sha }}
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Simplified the tag checkout process in the publish_npm job
- Fixed issue where the workflow failed to checkout newly created release tags

## Problem
The publish workflow was failing with error:
```
error: pathspec 'v3.0.0' did not match any file(s) known to git
```

This occurred because the release job creates a tag, but it wasn't immediately available for checkout in the publish job.

## Solution
Changed from a two-step process (checkout then fetch/checkout tag) to using the `ref` parameter directly in the checkout action:
- Before: Checkout repository, then fetch tags and checkout specific tag
- After: Direct checkout using `ref: ${{ needs.release.outputs.tag || github.sha }}`

This approach is more reliable because the checkout action handles fetching the necessary refs automatically.

## Test Plan
- [x] Workflow syntax is valid
- [ ] Next release will validate that the publish job can checkout the release tag correctly