### PR TITLE
fix: skip prompting for identical files during setup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,19 @@ async function setupAiCodingAssistants(
     const exists = await fs.pathExists(target);
 
     if (exists && !force) {
+      // Check if files are identical
+      const sourceContent = await fs.readFile(source, 'utf-8');
+      const targetContent = await fs.readFile(target, 'utf-8');
+
+      if (sourceContent === targetContent) {
+        // Files are identical, skip silently
+        if (verbose) {
+          Feedback.info(`   [SKIP] ${relativePath} (identical)`);
+        }
+        skippedCount++;
+        continue;
+      }
+
       if (interactive) {
         const { default: inquirer } = await import('inquirer');
         const { overwrite } = await inquirer.prompt([


### PR DESCRIPTION
## Summary
- Skip prompting users when template files are identical to existing files
- Improves user experience by avoiding unnecessary prompts

## Description
When running the setup command, if a file already exists with identical content to the source template, the setup now silently skips it instead of prompting the user. This improves the user experience by avoiding unnecessary prompts for files that are already in sync.

### Changes
- Added file content comparison before prompting
- Files with identical content are skipped silently  
- In verbose mode, shows "(identical)" status for skipped files
- Different files still prompt as before

## Test plan
- [ ] Run `npx ai-coding-assistants-setup` in a project with existing config files
- [ ] Verify identical files are skipped without prompting
- [ ] Verify different files still prompt for overwrite confirmation
- [ ] Test with `--verbose` flag to see "(identical)" status messages
- [ ] Test with `--force` flag to ensure it still overwrites all files