### PR TITLE
fix(workflows): allow low/moderate vulnerabilities in npm security scan

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -590,10 +590,26 @@ jobs:
       - name: 🔒 Run security audit
         run: |
           if [ "${{ inputs.package_manager }}" = "npm" ]; then
-            npm audit --production
+            # Run audit and only fail on high or critical vulnerabilities
+            npm audit --production --audit-level=high || exit_code=$?
+            if [ "${exit_code:-0}" -ne 0 ]; then
+              echo "::warning::Found high or critical vulnerabilities"
+              exit $exit_code
+            fi
           elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
-            yarn audit --groups dependencies
+            # Yarn audit doesn't support audit-level, so we need to parse output
+            yarn audit --groups dependencies --json | jq -r '.advisories | to_entries[] | select(.value.severity == "high" or .value.severity == "critical") | .value' > high_vulns.json
+            if [ -s high_vulns.json ]; then
+              echo "::error::Found high or critical vulnerabilities:"
+              cat high_vulns.json
+              exit 1
+            else
+              echo "::notice::No high or critical vulnerabilities found"
+            fi
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            # Bun doesn't support audit levels yet, so we'll use the default behavior
+            # but add a note that it may fail on all vulnerability levels
+            echo "::warning::Bun audit doesn't support severity filtering yet"
             bun pm audit
           else
             echo "Unsupported package manager: ${{ inputs.package_manager }}"

--- a/src/templates/.github/workflows/quality.yml
+++ b/src/templates/.github/workflows/quality.yml
@@ -590,10 +590,26 @@ jobs:
       - name: 🔒 Run security audit
         run: |
           if [ "${{ inputs.package_manager }}" = "npm" ]; then
-            npm audit --production
+            # Run audit and only fail on high or critical vulnerabilities
+            npm audit --production --audit-level=high || exit_code=$?
+            if [ "${exit_code:-0}" -ne 0 ]; then
+              echo "::warning::Found high or critical vulnerabilities"
+              exit $exit_code
+            fi
           elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
-            yarn audit --groups dependencies
+            # Yarn audit doesn't support audit-level, so we need to parse output
+            yarn audit --groups dependencies --json | jq -r '.advisories | to_entries[] | select(.value.severity == "high" or .value.severity == "critical") | .value' > high_vulns.json
+            if [ -s high_vulns.json ]; then
+              echo "::error::Found high or critical vulnerabilities:"
+              cat high_vulns.json
+              exit 1
+            else
+              echo "::notice::No high or critical vulnerabilities found"
+            fi
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            # Bun doesn't support audit levels yet, so we'll use the default behavior
+            # but add a note that it may fail on all vulnerability levels
+            echo "::warning::Bun audit doesn't support severity filtering yet"
             bun pm audit
           else
             echo "Unsupported package manager: ${{ inputs.package_manager }}"


### PR DESCRIPTION
## Summary
- Configure npm security scan to only fail on high/critical vulnerabilities
- Prevent CI failures for low and moderate security issues that don't require immediate attention

## Changes
- **npm**: Added `--audit-level=high` flag to only fail on high/critical vulnerabilities
- **yarn**: Implemented JSON parsing with `jq` to filter for high/critical vulnerabilities only
- **bun**: Added warning that severity filtering is not yet supported
- Updated both the main workflow file and template workflow file

## Motivation
Many projects have low or moderate vulnerabilities from dependencies that are either:
- Not exploitable in the project's context
- Awaiting upstream fixes
- In dev dependencies only

This change allows teams to focus on high and critical vulnerabilities that pose real security risks while still being aware of lower severity issues through warnings.

## Test plan
- [ ] npm projects with only low/moderate vulnerabilities will pass security scan
- [ ] npm projects with high/critical vulnerabilities will fail security scan
- [ ] yarn projects will correctly filter vulnerabilities by severity
- [ ] bun projects will show appropriate warning about lack of severity filtering