### PR TITLE
fix: replace jq with gh's built-in --jq flag to avoid parse errors

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -25,7 +25,7 @@ if ! gh repo view &> /dev/null; then
 fi
 
 # Check if there's an open PR for this branch
-PR_INFO=$(gh pr view --json number,body,author 2>/dev/null || echo "")
+PR_INFO=$(gh pr view --json number 2>/dev/null || echo "")
 
 if [ -z "$PR_INFO" ]; then
   # No PR exists yet, check if we're creating one
@@ -41,8 +41,8 @@ if [ -z "$PR_INFO" ]; then
   exit 0
 fi
 
-# Extract PR body with better error handling
-PR_BODY=$(echo "$PR_INFO" | jq -r '.body // ""' 2>/dev/null || echo "")
+# Extract PR body using gh's built-in jq functionality
+PR_BODY=$(gh pr view --json body --jq '.body' 2>/dev/null || echo "")
 if [ -z "$PR_BODY" ] && [ -n "$PR_INFO" ]; then
   echo ""
   echo "❌ Error parsing PR information from GitHub"
@@ -61,7 +61,7 @@ if [ -z "$PR_BODY" ] && [ -n "$PR_INFO" ]; then
   exit 1
 fi
 
-PR_AUTHOR=$(echo "$PR_INFO" | jq -r '.author.login // ""' 2>/dev/null || echo "")
+PR_AUTHOR=$(gh pr view --json author --jq '.author.login' 2>/dev/null || echo "")
 
 # Check for AI-generated PR patterns
 AI_PR_PATTERNS=(

--- a/src/templates/.husky/pre-push
+++ b/src/templates/.husky/pre-push
@@ -25,7 +25,7 @@ if ! gh repo view &> /dev/null; then
 fi
 
 # Check if there's an open PR for this branch
-PR_INFO=$(gh pr view --json number,body,author 2>/dev/null || echo "")
+PR_INFO=$(gh pr view --json number 2>/dev/null || echo "")
 
 if [ -z "$PR_INFO" ]; then
   # No PR exists yet, check if we're creating one
@@ -41,8 +41,8 @@ if [ -z "$PR_INFO" ]; then
   exit 0
 fi
 
-# Extract PR body with better error handling
-PR_BODY=$(echo "$PR_INFO" | jq -r '.body // ""' 2>/dev/null || echo "")
+# Extract PR body using gh's built-in jq functionality
+PR_BODY=$(gh pr view --json body --jq '.body' 2>/dev/null || echo "")
 if [ -z "$PR_BODY" ] && [ -n "$PR_INFO" ]; then
   echo ""
   echo "❌ Error parsing PR information from GitHub"
@@ -61,7 +61,7 @@ if [ -z "$PR_BODY" ] && [ -n "$PR_INFO" ]; then
   exit 1
 fi
 
-PR_AUTHOR=$(echo "$PR_INFO" | jq -r '.author.login // ""' 2>/dev/null || echo "")
+PR_AUTHOR=$(gh pr view --json author --jq '.author.login' 2>/dev/null || echo "")
 
 # Check for AI-generated PR patterns
 AI_PR_PATTERNS=(


### PR DESCRIPTION
## Summary
- Replaced external jq command with gh CLI's built-in --jq functionality
- Prevents JSON parse errors with control characters
- Provides more reliable GitHub API response handling

## Problem
The previous implementation was encountering parse errors:
```
parse error: Invalid string: control characters from U+0000 through U+001F must be escaped
```

## Solution
Using gh's built-in --jq flag instead of piping to external jq command:
- `gh pr view --json body --jq '.body'` instead of `echo "$PR_INFO" | jq -r '.body'`
- `gh pr view --json author --jq '.author.login'` for author info

## Changes
- Updated .husky/pre-push to use gh's --jq flag
- Updated src/templates/.husky/pre-push with the same fix
- Maintained all existing error handling and user-friendly messages

## Test plan
- Verify pre-push hook works correctly when checking PR status
- Confirm no more JSON parse errors occur
- Test that AI-generated PR detection still functions properly

🤖 Generated with [Claude Code](https://claude.ai/code)